### PR TITLE
Add instanced command handlers

### DIFF
--- a/src/Discord.Net.Interactions.Abstractions/ICommandHandlerCreator.cs
+++ b/src/Discord.Net.Interactions.Abstractions/ICommandHandlerCreator.cs
@@ -27,8 +27,7 @@ namespace Discord.Net.Interactions.Abstractions
     /// Creator of SlashCommandHandler different types may be used for subcommands or custom matching
     /// </summary>
     /// <typeparam name="TMatcherType">Type that will be passed to the matcher as argument</typeparam>
-    /// <typeparam name="TDelegateType">Type of the delegate that will be called as the handler</typeparam>
-    public interface ICommandHandlerCreator<TMatcherType, TDelegateType>
+    public interface ICommandHandlerCreator<TMatcherType>
     {
         /// <summary>
         /// Creates SlashCommandHandler for given matches
@@ -36,7 +35,7 @@ namespace Discord.Net.Interactions.Abstractions
         /// <param name="matchers">List of matchers that specify what function is matched given conditions</param>
         /// <returns></returns>
         public SlashCommandHandler CreateHandlerForCommand(
-            IEnumerable<(Func<TMatcherType, bool>, TDelegateType)> matchers);
+            IEnumerable<(Func<TMatcherType, bool>, Delegate)> matchers);
 
         //InstancedSlashCommandHandle
 

--- a/src/Discord.Net.Interactions.Abstractions/ICommandHandlerCreator.cs
+++ b/src/Discord.Net.Interactions.Abstractions/ICommandHandlerCreator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Discord.WebSocket;
@@ -7,11 +8,20 @@ using Discord.WebSocket;
 namespace Discord.Net.Interactions.Abstractions
 {
     public delegate Task CommandDelegate(SocketSlashCommand command, CancellationToken token);
+
     public delegate Task CommandDelegate<in T1>(SocketSlashCommand command, T1 arg1, CancellationToken token);
-    public delegate Task CommandDelegate<in T1, in T2>(SocketSlashCommand command, T1 arg1, T2 arg2, CancellationToken token);
-    public delegate Task CommandDelegate<in T1, in T2, in T3>(SocketSlashCommand command, T1 arg1, T2 arg2, T3 arg3, CancellationToken token);
-    public delegate Task CommandDelegate<in T1, in T2, in T3, in T4>(SocketSlashCommand command, T1 arg1, T2 arg2, T3 arg3, T4 arg4, CancellationToken token);
-    public delegate Task CommandDelegate<in T1, in T2, in T3, in T4, T5>(SocketSlashCommand command, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, CancellationToken token);
+
+    public delegate Task CommandDelegate<in T1, in T2>(SocketSlashCommand command, T1 arg1, T2 arg2,
+        CancellationToken token);
+
+    public delegate Task CommandDelegate<in T1, in T2, in T3>(SocketSlashCommand command, T1 arg1, T2 arg2, T3 arg3,
+        CancellationToken token);
+
+    public delegate Task CommandDelegate<in T1, in T2, in T3, in T4>(SocketSlashCommand command, T1 arg1, T2 arg2,
+        T3 arg3, T4 arg4, CancellationToken token);
+
+    public delegate Task CommandDelegate<in T1, in T2, in T3, in T4, T5>(SocketSlashCommand command, T1 arg1, T2 arg2,
+        T3 arg3, T4 arg4, T5 arg5, CancellationToken token);
 
     /// <summary>
     /// Creator of SlashCommandHandler different types may be used for subcommands or custom matching
@@ -25,6 +35,17 @@ namespace Discord.Net.Interactions.Abstractions
         /// </summary>
         /// <param name="matchers">List of matchers that specify what function is matched given conditions</param>
         /// <returns></returns>
-        public SlashCommandHandler CreateHandlerForCommand(IEnumerable<(Func<TMatcherType, bool>, TDelegateType)> matchers);
+        public SlashCommandHandler CreateHandlerForCommand(
+            IEnumerable<(Func<TMatcherType, bool>, TDelegateType)> matchers);
+
+        //InstancedSlashCommandHandle
+
+        /// <summary>
+        /// Creates SlashCommandHandler for given matches
+        /// </summary>
+        /// <param name="matchers">List of matchers that specify what function is matched given conditions</param>
+        /// <returns></returns>
+        public InstancedSlashCommandHandler CreateInstancedHandlerForCommand(
+            IEnumerable<(Func<TMatcherType, bool>, MethodInfo)> matchers);
     }
 }

--- a/src/Discord.Net.Interactions.Abstractions/ICommandHandlerCreator.cs
+++ b/src/Discord.Net.Interactions.Abstractions/ICommandHandlerCreator.cs
@@ -41,8 +41,12 @@ namespace Discord.Net.Interactions.Abstractions
         //InstancedSlashCommandHandle
 
         /// <summary>
-        /// Creates SlashCommandHandler for given matches
+        /// Creates InstancedSlashCommandHandler for given matches
         /// </summary>
+        /// <remarks>
+        /// Instanced slash command handler can be used to invoke command with different class instance
+        /// every time
+        /// </remarks>
         /// <param name="matchers">List of matchers that specify what function is matched given conditions</param>
         /// <returns></returns>
         public InstancedSlashCommandHandler CreateInstancedHandlerForCommand(

--- a/src/Discord.Net.Interactions.Abstractions/ICommandHandlerCreatorExtensions.cs
+++ b/src/Discord.Net.Interactions.Abstractions/ICommandHandlerCreatorExtensions.cs
@@ -14,7 +14,7 @@ namespace Discord.Net.Interactions.Abstractions
         /// <param name="deleg">Delegate to execute with the command</param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static SlashCommandHandler CreateHandlerForCommand<T>(this ICommandHandlerCreator<T, Delegate> creator,
+        public static SlashCommandHandler CreateHandlerForCommand<T>(this ICommandHandlerCreator<T> creator,
             Delegate deleg)
         {
             return creator
@@ -29,7 +29,7 @@ namespace Discord.Net.Interactions.Abstractions
         /// <param name="matchers"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static SlashCommandHandler CreateHandlerForCommand<T, U>(this ICommandHandlerCreator<T, U> creator, params (Func<T, bool>, U)[] matchers)
+        public static SlashCommandHandler CreateHandlerForCommand<T>(this ICommandHandlerCreator<T> creator, params (Func<T, bool>, Delegate)[] matchers)
         {
             return creator.CreateHandlerForCommand(matchers.AsEnumerable());
         }
@@ -42,13 +42,13 @@ namespace Discord.Net.Interactions.Abstractions
         /// <param name="matchers"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static SlashCommandHandler CreateHandlerForCommand<T, U>(this ICommandHandlerCreator<T, U> creator,
-            params (T, U)[] matchers)
+        public static SlashCommandHandler CreateHandlerForCommand<T>(this ICommandHandlerCreator<T> creator,
+            params (T, Delegate)[] matchers)
         where T : notnull
         {
             return creator
                 .CreateHandlerForCommand(matchers.Select(
-                    x => ValueTuple.Create<Func<T, bool>, U>(((y) => x.Item1.Equals(y)), x.Item2)));
+                    x => ValueTuple.Create<Func<T, bool>, Delegate>(((y) => x.Item1.Equals(y)), x.Item2)));
         }
         
                 /// <summary>
@@ -59,7 +59,7 @@ namespace Discord.Net.Interactions.Abstractions
         /// <param name="deleg">Delegate to execute with the command</param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static InstancedSlashCommandHandler CreateInstancedHandlerForCommand<T, U>(this ICommandHandlerCreator<T, U> creator,
+        public static InstancedSlashCommandHandler CreateInstancedHandlerForCommand<T>(this ICommandHandlerCreator<T> creator,
             MethodInfo methodInfo)
         {
             return creator
@@ -74,7 +74,7 @@ namespace Discord.Net.Interactions.Abstractions
         /// <param name="matchers"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static InstancedSlashCommandHandler CreateInstancedHandlerForCommand<T, U>(this ICommandHandlerCreator<T, U> creator, params (Func<T, bool>, MethodInfo)[] matchers)
+        public static InstancedSlashCommandHandler CreateInstancedHandlerForCommand<T>(this ICommandHandlerCreator<T> creator, params (Func<T, bool>, MethodInfo)[] matchers)
         {
             return creator.CreateInstancedHandlerForCommand(matchers.AsEnumerable());
         }
@@ -87,7 +87,7 @@ namespace Discord.Net.Interactions.Abstractions
         /// <param name="matchers"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static InstancedSlashCommandHandler CreateInstancedHandlerForCommand<T, U>(this ICommandHandlerCreator<T, U> creator,
+        public static InstancedSlashCommandHandler CreateInstancedHandlerForCommand<T>(this ICommandHandlerCreator<T> creator,
             params (T, MethodInfo)[] matchers)
         where T : notnull
         {

--- a/src/Discord.Net.Interactions.Abstractions/ICommandHandlerCreatorExtensions.cs
+++ b/src/Discord.Net.Interactions.Abstractions/ICommandHandlerCreatorExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Reflection;
 
 namespace Discord.Net.Interactions.Abstractions
 {
@@ -48,6 +49,51 @@ namespace Discord.Net.Interactions.Abstractions
             return creator
                 .CreateHandlerForCommand(matchers.Select(
                     x => ValueTuple.Create<Func<T, bool>, U>(((y) => x.Item1.Equals(y)), x.Item2)));
+        }
+        
+                /// <summary>
+        /// Passes one matcher that always return true to <see cref="ICommandHandlerCreator{T}.CreateHandlerForCommand"/>
+        /// Creates SlashCommandHandler that will always execute given delegate
+        /// </summary>
+        /// <param name="creator"></param>
+        /// <param name="deleg">Delegate to execute with the command</param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static InstancedSlashCommandHandler CreateInstancedHandlerForCommand<T, U>(this ICommandHandlerCreator<T, U> creator,
+            MethodInfo methodInfo)
+        {
+            return creator
+                .CreateInstancedHandlerForCommand((_ => true, methodInfo));
+        }
+
+        /// <summary>
+        /// Passes params to <see cref="ICommandHandlerCreator{T}.CreateHandlerForCommand"/>
+        /// Creates SlashCommandHandler based on matchers
+        /// </summary>
+        /// <param name="creator"></param>
+        /// <param name="matchers"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static InstancedSlashCommandHandler CreateInstancedHandlerForCommand<T, U>(this ICommandHandlerCreator<T, U> creator, params (Func<T, bool>, MethodInfo)[] matchers)
+        {
+            return creator.CreateInstancedHandlerForCommand(matchers.AsEnumerable());
+        }
+
+        /// <summary>
+        /// Passes equals matchers to <see cref="ICommandHandlerCreator{T}.CreateHandlerForCommand"/>
+        /// Creates SlashCommandHandler matching T objects in matchers
+        /// </summary>
+        /// <param name="creator"></param>
+        /// <param name="matchers"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static InstancedSlashCommandHandler CreateInstancedHandlerForCommand<T, U>(this ICommandHandlerCreator<T, U> creator,
+            params (T, MethodInfo)[] matchers)
+        where T : notnull
+        {
+            return creator
+                .CreateInstancedHandlerForCommand(matchers.Select(
+                    x => ValueTuple.Create<Func<T, bool>, MethodInfo>(((y) => x.Item1.Equals(y)), x.Item2)));
         }
     }
 }

--- a/src/Discord.Net.Interactions.Abstractions/SlashCommandInfo.cs
+++ b/src/Discord.Net.Interactions.Abstractions/SlashCommandInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Discord.Rest;
@@ -5,22 +6,41 @@ using Discord.WebSocket;
 
 namespace Discord.Net.Interactions.Abstractions
 {
-    public delegate Task SlashCommandHandler(SocketSlashCommand command, CancellationToken token = new CancellationToken());
+    public delegate Task SlashCommandHandler(SocketSlashCommand command,
+        CancellationToken token = new CancellationToken());
+
+    public delegate Task InstancedSlashCommandHandler(object classInstance, SocketSlashCommand command,
+        CancellationToken token = new CancellationToken());
 
     /// <summary>
     /// Information about a slash command
     /// </summary>
     public class SlashCommandInfo
     {
-        public SlashCommandInfo(SlashCommandBuilder builder,
-            SlashCommandHandler handler, bool global, ulong? guildId)
+        private SlashCommandInfo(SlashCommandBuilder builder, bool global, ulong? guildId)
         {
+
             BuiltCommand = builder.Build();
-            Handler = handler;
             Global = global;
             GuildId = guildId;
         }
         
+        public SlashCommandInfo(SlashCommandBuilder builder,
+            SlashCommandHandler handler, bool global, ulong? guildId)
+        : this (builder, global, guildId)
+        {
+
+            Handler = handler;
+        }
+        
+        public SlashCommandInfo(SlashCommandBuilder builder,
+            InstancedSlashCommandHandler instancedHandler, bool global, ulong? guildId)
+            : this (builder, global, guildId)
+        {
+
+            InstancedHandler = instancedHandler;
+        }
+
         /// <summary>
         /// If the command was registered yet
         /// </summary>
@@ -30,22 +50,27 @@ namespace Discord.Net.Interactions.Abstractions
         /// Whether it should be a global command
         /// </summary>
         public bool Global { get; } = false;
-        
+
         /// <summary>
         /// What guild to add the command to
         /// </summary>
         public ulong? GuildId { get; }
+
+        /// <summary>
+        /// What handler to execute when command execution is requested
+        /// </summary>
+        public SlashCommandHandler? Handler { get; }
         
         /// <summary>
         /// What handler to execute when command execution is requested
         /// </summary>
-        public SlashCommandHandler Handler { get; }
+        public InstancedSlashCommandHandler? InstancedHandler { get; }
 
         /// <summary>
         /// Built command that is set after calling Build()
         /// </summary>
         public SlashCommandCreationProperties BuiltCommand { get; }
-        
+
         /// <summary>
         /// Registered command that is set after calling RegisterCommandAsync
         /// </summary>

--- a/src/Discord.Net.Interactions.Abstractions/SlashCommandInfo.cs
+++ b/src/Discord.Net.Interactions.Abstractions/SlashCommandInfo.cs
@@ -6,9 +6,17 @@ using Discord.WebSocket;
 
 namespace Discord.Net.Interactions.Abstractions
 {
+    /// <summary>
+    /// Handler function of slash commands without instance, <see cref="InstancedSlashCommandHandler"/> for
+    /// command handler that can be invoked with different instances
+    /// </summary>
     public delegate Task SlashCommandHandler(SocketSlashCommand command,
         CancellationToken token = new CancellationToken());
 
+    /// <summary>
+    /// Handler function of slash commands supporting invoking with different class instances
+    /// for holding context per command
+    /// </summary>
     public delegate Task InstancedSlashCommandHandler(object classInstance, SocketSlashCommand command,
         CancellationToken token = new CancellationToken());
 

--- a/src/Discord.Net.Interactions/CommandsInfo/SlashCommandInfoBuilder.cs
+++ b/src/Discord.Net.Interactions/CommandsInfo/SlashCommandInfoBuilder.cs
@@ -8,12 +8,24 @@ namespace Discord.Net.Interactions.CommandsInfo
     {
         public override SlashCommandInfo Build()
         {
-            if (DiscordNetBuilder == null || Handler == null)
+            if (DiscordNetBuilder is null)
             {
-                throw new InvalidOperationException("DiscordNetBuilder, Permission and Handler must be set");
+                throw new InvalidOperationException("DiscordNetBuilder must be set");
             }
 
-            SlashCommandInfo info = new SlashCommandInfo(DiscordNetBuilder, Handler, Global, GuildId);
+            SlashCommandInfo info;
+            if (Handler is not null)
+            {
+                info = new SlashCommandInfo(DiscordNetBuilder, Handler, Global, GuildId);
+            }
+            else if (InstancedHandler is not null)
+            {
+                info = new SlashCommandInfo(DiscordNetBuilder, InstancedHandler, Global, GuildId);
+            }
+            else
+            {
+                throw new InvalidOperationException("At least one of Handler, InstancedHandler must be set");
+            }
 
             return info;
         }
@@ -46,6 +58,11 @@ namespace Discord.Net.Interactions.CommandsInfo
         public SlashCommandHandler? Handler { get; set; }
 
         /// <summary>
+        /// Handler that will be called when the command was executed by a user
+        /// </summary>
+        public InstancedSlashCommandHandler? InstancedHandler { get; set; }
+
+        /// <summary>
         /// Builder used to build SlashCommandCreationOptions
         /// </summary>
         public SlashCommandBuilder? DiscordNetBuilder { get; set; }
@@ -69,6 +86,17 @@ namespace Discord.Net.Interactions.CommandsInfo
         public TBuilder WithHandler(SlashCommandHandler handler)
         {
             Handler = handler;
+            return _builderInstance;
+        }
+
+        /// <summary>
+        /// Set command handler deleagate to be called when handling the command
+        /// </summary>
+        /// <param name="handler"></param>
+        /// <returns></returns>
+        public TBuilder WithHandler(InstancedSlashCommandHandler handler)
+        {
+            InstancedHandler = handler;
             return _builderInstance;
         }
 

--- a/src/Discord.Net.Interactions/Executors/HandlerCommandExecutor.cs
+++ b/src/Discord.Net.Interactions/Executors/HandlerCommandExecutor.cs
@@ -24,6 +24,11 @@ namespace Discord.Net.Interactions.Executors
         {
             try
             {
+                if (info.Handler is null)
+                {
+                    throw new InvalidOperationException("HandlerCommandExecutor can handle only non-instanced commands");
+                }
+                
                 _logger.LogInformation($@"Handling command /{command.Data.Name} executed by {command.User.Mention} ({command.User})");
                 await info.Handler(command, token);
             }

--- a/src/Discord.Net.Interactions/Executors/InstancedCommandExecutor.cs
+++ b/src/Discord.Net.Interactions/Executors/InstancedCommandExecutor.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Discord.Net.Interactions.Abstractions;
+using Discord.WebSocket;
+using Microsoft.Extensions.Logging;
+
+namespace Discord.Net.Interactions.Executors
+{
+    public class InstancedCommandExecutor<TSlashInfo> : ICommandExecutor<TSlashInfo>
+        where TSlashInfo : SlashCommandInfo
+    {
+        private readonly ILogger _logger;
+        private Func<SlashCommandInfo, SocketSlashCommand, CancellationToken, object> _getInstance;
+
+        public InstancedCommandExecutor(ILogger logger,
+            Func<SlashCommandInfo, SocketSlashCommand, CancellationToken, object> getInstance)
+        {
+            _logger = logger;
+            _getInstance = getInstance;
+        }
+
+        public async Task TryExecuteCommand(TSlashInfo info, SocketSlashCommand command, CancellationToken token = default)
+        {
+            try
+            {
+                if (info.InstancedHandler is null)
+                {
+                    throw new InvalidOperationException("InstancedCommandExecutor can handle only instanced commands");
+                }
+
+                _logger.LogInformation(
+                    $@"Handling command /{command.Data.Name} executed by {command.User.Mention} ({command.User})");
+                
+                object instance = _getInstance(info, command, token);
+                await info.InstancedHandler(instance, command, token);
+            }
+            catch (OperationCanceledException)
+            {
+                token.ThrowIfCancellationRequested();
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $@"Command handler for command /{command.Data.Name} has thrown an exception");
+            }
+        }
+    }
+}

--- a/src/Discord.Net.Interactions/Executors/InstancedCommandExecutor.cs
+++ b/src/Discord.Net.Interactions/Executors/InstancedCommandExecutor.cs
@@ -8,12 +8,19 @@ using Microsoft.Extensions.Logging;
 
 namespace Discord.Net.Interactions.Executors
 {
+    /// <summary>
+    /// Execute InstancedHandler of slash command info.
+    /// Delegate to obtain instance with will be passed to the constructor.
+    /// </summary>
+    /// <typeparam name="TSlashInfo"></typeparam>
     public class InstancedCommandExecutor<TSlashInfo> : ICommandExecutor<TSlashInfo>
         where TSlashInfo : SlashCommandInfo
     {
         private readonly ILogger _logger;
         private Func<SlashCommandInfo, SocketSlashCommand, CancellationToken, object> _getInstance;
-
+        
+        /// <param name="logger">Logger to log errors with</param>
+        /// <param name="getInstance">Obtain new instance for execution of the command</param>
         public InstancedCommandExecutor(ILogger logger,
             Func<SlashCommandInfo, SocketSlashCommand, CancellationToken, object> getInstance)
         {

--- a/src/Discord.Net.Interactions/HandlerCreator/CommandHandlerCreatorUtils.cs
+++ b/src/Discord.Net.Interactions/HandlerCreator/CommandHandlerCreatorUtils.cs
@@ -12,14 +12,13 @@ namespace Discord.Net.Interactions.HandlerCreator
 {
     public class CommandHandlerCreatorUtils
     {
-
         /// <summary>
-        /// Create SlashCommandHandler from given Delegate.
-        /// It should have the following signature: SocketSlashCommand, *arguments for the command with matching names*, CancellationToken
+        /// Create SlashCommandHandler from given EfficientInvoker.
+        /// It should have the following signature: SocketSlashCommand, *arguments for the command with matching names*, CancellationToken.
         /// Uses <see cref="EfficientInvoker"/> for invoking the delegate faster.
         /// </summary>
-        /// <param name="function">What function to call during handling</param>
-        /// <param name="getArguments">Function to obtain arguments for the delegate with</param>
+        /// <param name="invoker">What invoker will be used to invoke the command</param>
+        /// <param name="getArguments">Function to obtain arguments for the invoker</param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
         public static InstancedSlashCommandHandler CreateHandler(EfficientInvoker invoker,
@@ -36,11 +35,15 @@ namespace Discord.Net.Interactions.HandlerCreator
         }
 
         /// <summary>
-        /// Create SlashCommandHandler from given Delegate.
+        /// Create SlashCommandHandler from given EfficientInvoker.
         /// It should have the following signature: SocketSlashCommand, *arguments for the command with matching names*, CancellationToken
         /// Uses <see cref="EfficientInvoker"/> for invoking the delegate faster.
         /// </summary>
-        /// <param name="function">What function to call during handling</param>
+        /// <remarks>
+        /// This function is different from non-generic CreateHandler, because getArguments function accepts generic helper argument
+        /// that can be used for storing anything important for retrieving arguments
+        /// </remarks>
+        /// <param name="invoker">What invoker will be used to invoke the command</param>
         /// <param name="getArguments">Function to obtain arguments for the delegate with</param>
         /// <returns></returns>
         /// <exception cref="InvalidOperationException"></exception>
@@ -57,6 +60,13 @@ namespace Discord.Net.Interactions.HandlerCreator
             };
         }
 
+        /// <summary>
+        /// Matches positions of options of command to method parameters.
+        /// Parameters will be matched to the names of the options of the command.
+        /// </summary>
+        /// <param name="methodInfo"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
         public static IEnumerable<object?> GetParametersFromOptions(MethodInfo methodInfo,
             IEnumerable<SocketSlashCommandDataOption>? options)
         {

--- a/src/Discord.Net.Interactions/HandlerCreator/PlainCommandHandlerCreator.cs
+++ b/src/Discord.Net.Interactions/HandlerCreator/PlainCommandHandlerCreator.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
 using Discord.Net.Interactions.Abstractions;
+using Discord.Net.Interactions.Reflection;
 
 namespace Discord.Net.Interactions.HandlerCreator
 {
@@ -14,23 +17,43 @@ namespace Discord.Net.Interactions.HandlerCreator
         public SlashCommandHandler CreateHandlerForCommand(IEnumerable<(Func<string, bool>, Delegate)> matchers)
         {
             var valueTuples = matchers as (Func<string, bool>, Delegate)[] ?? matchers.ToArray();
-            if (valueTuples.Count() != 1)
+
+            Delegate matchedDelegate = GetMatched<Delegate>(valueTuples);
+            InstancedSlashCommandHandler instancedHandler = CommandHandlerCreatorUtils.CreateHandler(
+                EfficientInvoker.ForDelegate(matchedDelegate),
+                (data => CommandHandlerCreatorUtils.GetParametersFromOptions(matchedDelegate.Method, data.Options)));
+
+            return (command, token) => instancedHandler(matchedDelegate, command, token);
+        }
+
+        public InstancedSlashCommandHandler CreateInstancedHandlerForCommand(
+            IEnumerable<(Func<string, bool>, MethodInfo)> matchers)
+        {
+            var valueTuples = matchers as (Func<string, bool>, MethodInfo)[] ?? matchers.ToArray();
+            MethodInfo matchedMethod = GetMatched<MethodInfo>(valueTuples);
+            EfficientInvoker invoker = EfficientInvoker.ForMethod(matchedMethod);
+
+            return GetHandler(CommandHandlerCreatorUtils.CreateHandler(invoker,
+                (data => CommandHandlerCreatorUtils.GetParametersFromOptions(matchedMethod, data.Options))));
+        }
+
+        private T GetMatched<T>((Func<string, bool>, T)[] valueTuples)
+        {
+            if (valueTuples.Length != 1)
             {
                 throw new InvalidOperationException(
                     "PlainCommandHandlerCreator can handle only one matcher that is always true");
             }
 
-            var matcher = valueTuples.FirstOrDefault();
-            return GetHandler(CommandHandlerCreatorUtils.CreateHandler(matcher.Item2,
-                (data => CommandHandlerCreatorUtils.GetParametersFromOptions(matcher.Item2, data.Options))));
+            return valueTuples.FirstOrDefault().Item2;
         }
 
-        private SlashCommandHandler GetHandler(SlashCommandHandler handler)
+        private InstancedSlashCommandHandler GetHandler(InstancedSlashCommandHandler handler)
         {
-            return (command, token) =>
+            return (instance, command, token) =>
             {
                 token.ThrowIfCancellationRequested();
-                return handler(command, token);
+                return handler(instance, command, token);
             };
         }
     }

--- a/src/Discord.Net.Interactions/HandlerCreator/PlainCommandHandlerCreator.cs
+++ b/src/Discord.Net.Interactions/HandlerCreator/PlainCommandHandlerCreator.cs
@@ -12,7 +12,7 @@ namespace Discord.Net.Interactions.HandlerCreator
     /// Creates SlashCommandHandler for command without subcommands.
     /// It should receive only 1 matcher and that should always match
     /// </summary>
-    public class PlainCommandHandlerCreator : ICommandHandlerCreator<string, Delegate>
+    public class PlainCommandHandlerCreator : ICommandHandlerCreator<string>
     {
         public SlashCommandHandler CreateHandlerForCommand(IEnumerable<(Func<string, bool>, Delegate)> matchers)
         {

--- a/src/Discord.Net.Interactions/HandlerCreator/SubCommandHandlerCreator.cs
+++ b/src/Discord.Net.Interactions/HandlerCreator/SubCommandHandlerCreator.cs
@@ -18,7 +18,7 @@ namespace Discord.Net.Interactions.HandlerCreator
     /// So for example, if we have /command subcmd subsubcmd, then
     /// matcher for "subcmd subsubcmd" should be present
     /// </summary>
-    public class SubCommandHandlerCreator : ICommandHandlerCreator<string, Delegate>
+    public class SubCommandHandlerCreator : ICommandHandlerCreator<string>
     {
         private HandlerMatcher<T> GetMatchedHandler<T>(List<HandlerMatcher<T>> matchers, SocketSlashCommand command,
             out SocketSlashCommandDataOption? outOption, CancellationToken token)


### PR DESCRIPTION
Before implementing controller pattern, it is better to be able to use different instances of classes for commands. That way there could be context saved in the instances.